### PR TITLE
Add p7zip

### DIFF
--- a/io.github.m64p.m64p.metainfo.xml
+++ b/io.github.m64p.m64p.metainfo.xml
@@ -13,7 +13,7 @@
       <p>m64p comes bundled with paraLLEl-RDP for graphics. It should give you the best out-of-the-box experience available for N64 gaming.</p>
   </description>
   <screenshots>
-      <screenshot type="default">https://raw.githubusercontent.com/gal20/flathub/io.github.m64p.m64p/m64p.png</screenshot>
+      <screenshot type="default">https://raw.githubusercontent.com/flathub/io.github.m64p.m64p/master/m64p.png</screenshot>
   </screenshots>
   <releases>
     <release version="v2021.6.23" date="2021-06-23"/>

--- a/io.github.m64p.m64p.yaml
+++ b/io.github.m64p.m64p.yaml
@@ -36,6 +36,24 @@ modules:
       - /lib/*.a
       - /lib/*.la
 
+  - name: p7zip
+    no-autogen: true
+    make-args:
+      - 7za
+    make-install-args:
+      - DEST_HOME=/app
+      - DEST_SHARE=/app/share
+    sources:
+      - type: git
+        url: https://github.com/jinfeihan57/p7zip.git
+        tag: v17.04
+        commit: 0b5b1b1a866d0e41cb7945e60a32262874e724aa
+        x-checker-data:
+          type: git
+    cleanup:
+      - /man
+      - /share
+
   - name: mupen64plus-core
     subdir: mupen64plus-core/projects/unix
     no-autogen: true


### PR DESCRIPTION
This is an additional dependency, required to load ROMs from compressed archives