### PR TITLE
Fix libvosk version

### DIFF
--- a/io.github.m64p.m64p.yaml
+++ b/io.github.m64p.m64p.yaml
@@ -154,21 +154,21 @@ modules:
       - install vosk-*/vosk/libvosk.so -t /app/bin
     sources:
       - type: file
-        url: https://github.com/alphacep/vosk-api/releases/download/0.3.30/vosk-0.3.30-py3-none-linux_x86_64.whl
+        url: https://github.com/alphacep/vosk-api/releases/download/v0.3.30/vosk-0.3.30-py3-none-linux_x86_64.whl
         sha256: 650a98bde70fed12ec80c94be8436e17b0e45c4dac8fe37c571ba4e1c6641505
         x-checker-data:
           type: json
           url: https://api.github.com/repos/alphacep/vosk-api/releases/latest
-          version-query: .tag_name
+          version-query: .tag_name | sub("^v"; "")
           url-query: .assets[] | select(.name=="vosk-" + $version + "-py3-none-linux_x86_64.whl")
             | .browser_download_url
       - type: file
-        url: https://github.com/alphacep/vosk-api/releases/download/0.3.30/vosk-0.3.30-py3-none-linux_aarch64.whl
+        url: https://github.com/alphacep/vosk-api/releases/download/v0.3.30/vosk-0.3.30-py3-none-linux_aarch64.whl
         sha256: 02298d49e1fd11cd835548cd92c7dd9bbf8b082dee19d2514f73ea33d3130126
         x-checker-data:
           type: json
           url: https://api.github.com/repos/alphacep/vosk-api/releases/latest
-          version-query: .tag_name
+          version-query: .tag_name | sub("^v"; "")
           url-query: .assets[] | select(.name=="vosk-" + $version + "-py3-none-linux_aarch64.whl")
             | .browser_download_url
 


### PR DESCRIPTION
The tag name was changed, and now it starts with `v`