### PR TITLE
Fix wrapper to allow use of CLI

### DIFF
--- a/gui-wrapper.sh
+++ b/gui-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export M64P_DISABLE_UPDATER=1
-/app/mupen64plus/mupen64plus-gui
+exec /app/mupen64plus/mupen64plus-gui "$@"


### PR DESCRIPTION
The wrapper introduced in f04b928 does not forward CLI argument to the program.

Fixes #55